### PR TITLE
Make usernames and room names case insensitive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -692,6 +692,11 @@
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "optional": true
     },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "body-parser": "^1.17.2",
     "express": "^4.15.4",
     "hbs": "^4.0.1",
+    "lodash": "^4.17.4",
     "moment": "^2.18.1",
     "mustache": "^2.3.0",
     "mustache-express": "^1.2.5",

--- a/server/server.js
+++ b/server/server.js
@@ -3,13 +3,16 @@ const path = require('path');
 const socketIO = require('socket.io');
 const http = require('http');
 const mustacheExpress = require('mustache-express');
+const _ = require('lodash');
+
+const {
+  Users
+} = require('./utils/users');
+var users = new Users();
 
 const {
   isRealString
 } = require('./utils/validation');
-const {
-  Users
-} = require('./utils/users');
 
 const publicPath = path.join(__dirname, '../public');
 const port = process.env.PORT || 3000;
@@ -17,7 +20,8 @@ const port = process.env.PORT || 3000;
 var app = express();
 var server = http.createServer(app);
 var io = socketIO(server);
-var users = new Users();
+
+
 
 var {
   generateMessage,
@@ -37,6 +41,17 @@ io.on('connection', (socket) => {
     if (!isRealString(params.name) || !isRealString(params.room)) {
       return callback('Name and room are required.')
     }
+
+    let existingUsers = users.getUserList(params.room);
+    let existingUserTest = existingUsers.filter((user) => {
+      return user.toLowerCase() === params.name.toLowerCase();
+    });
+
+    if(existingUserTest.length > 0){
+      return callback('Name already in use, please choose another.')
+    };
+
+    var standardizeRoom = _.startCase(_.toLower(params.room));
 
     socket.join(params.room);
     users.removeUser(socket.id);


### PR DESCRIPTION
Simplified the user experience so that only one username can be chosen and the usernames are case insensitive

Joining the room "Games", "games", and "GAMES" takes the user to the same chat. Before it took them to different chats.